### PR TITLE
TOOLS-2557 Use clean target from Makefile.rust.targ in eng

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,9 +120,6 @@ pg: deps/postgresql12/.git
 doc: | $(CARGO_EXEC)
 	$(CARGO) doc
 
-clean:: | $(CARGO_EXEC)
-	$(CARGO) clean
-
 .PHONY: agent
 agent: | $(CARGO_EXEC)
 	STAMP=$(STAMP) $(CARGO) build --manifest-path=agent/Cargo.toml --release


### PR DESCRIPTION
The `clean` target in `Makefile.rust.targ` is preferred as it doesn't have a dependency on `$(CARGO_EXEC)`. Using the `clean` target such as the one removed in this PR causes issues when invoking `make distclean agent` (though there is no issue when invoking the targets separately) where `clean` requires `$(CARGO_EXEC)` but then it's immediately removed by `distclean` and though `$(CARGO_EXEC)` is a dependency of `agent` Make thinks it was already just built and the `agent` target fails.